### PR TITLE
Enhancements for running MinIO in different modes

### DIFF
--- a/.pipeline/pipeline-cli
+++ b/.pipeline/pipeline-cli
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export OCP_PIPELINE_VERSION='0.0.6'
+export OCP_PIPELINE_VERSION='0.0.7'
 OCP_PIPELINE_CLI_URL="https://raw.githubusercontent.com/BCDevOps/ocp-cd-pipeline/v${OCP_PIPELINE_VERSION}/src/main/resources/pipeline-cli"
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,7 @@ RUN curl -o minio https://dl.minio.io/server/minio/release/linux-amd64/minio && 
     curl -o mc https://dl.minio.io/client/mc/release/linux-amd64/mc && \
     chmod +x minio && \
     chmod +x mc && \
-    mkdir config && \
     mkdir data  && \
-    mkdir s3 && \
-    mkdir s3/config && \
-    mkdir s3/data && \    
     chown minio:root -R . && chmod 777 -R .
 
 USER minio
@@ -23,10 +19,8 @@ ENV MINIO_ACCESS_KEY="demoaccesskey"
 ENV MINIO_SECRET_KEY="mysecret"
 ENV MINIO_BIN=/opt/minio/minio
 ENV MINIO_MODE="server"
-ENV MINIO_DATA_DIR=/opt/minio/s3/data
-ENV MINIO_CONFIG_DIR=/opt/minio/s3/config
+ENV MINIO_DATA_DIR=/opt/minio/data
 
-VOLUME $MINIO_CONFIG_DIR
 VOLUME $MINIO_DATA_DIR
 
 EXPOSE 9000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ USER minio
 ENV MINIO_ACCESS_KEY="demoaccesskey"
 ENV MINIO_SECRET_KEY="mysecret"
 ENV MINIO_BIN=/opt/minio/minio
+ENV MINIO_MODE="server"
 ENV MINIO_DATA_DIR=/opt/minio/s3/data
 ENV MINIO_CONFIG_DIR=/opt/minio/s3/config
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${MINIO_BIN} ${MINIO_MODE} --config-dir=${MINIO_CONFIG_DIR} $@ ${MINIO_DATA_DIR}
+${MINIO_BIN} ${MINIO_MODE} $@ ${MINIO_DATA_DIR}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-${MINIO_BIN} server --config-dir=${MINIO_CONFIG_DIR} $@ ${MINIO_DATA_DIR}
+${MINIO_BIN} ${MINIO_MODE} --config-dir=${MINIO_CONFIG_DIR} $@ ${MINIO_DATA_DIR}

--- a/openshift/minio-bc.json
+++ b/openshift/minio-bc.json
@@ -1,7 +1,18 @@
 {
   "kind": "Template",
   "apiVersion": "v1",
-  "metadata": {},
+  "metadata": {
+    "name": "${NAME}",
+    "annotations": {
+      "description": "Minio with persistent storage build. By BC Gov.",
+      "iconClass": "icon-hdd",
+      "openshift.io/display-name": "BC Gov Minio",
+      "tags": "bcgov,pathfinder,minio,s3,objectstore",
+      "template.openshift.io/documentation-url": "https://github.com/BCDevOps/minio-openshift",
+      "template.openshift.io/long-description": "This template builds a minio server image within OpenShift, backed by persistent volume storage.",
+      "template.openshift.io/provider-display-name": "Province of BC, Office of the Chief Information Officer, BC DevExchange and DevOps Branch"
+    }
+  },
   "objects": [
       {
         "apiVersion": "v1",
@@ -53,7 +64,11 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "${NAME}${SUFFIX}",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "labels": {
+          "app": "${NAME}",
+          "buildconfig": "${NAME}"
+        }
       },
       "spec": {
         "triggers": [
@@ -103,11 +118,11 @@
       "displayName": "Name",
       "description": "The name assigned to all objects defined in this template.",
       "required": true,
-      "value": "nginx-runtime"
+      "value": "minio"
     },
     {
       "name": "SUFFIX",
-      "value": "-dev"
+      "value": "-build"
     },
     {
       "name": "GIT_REPO_URL",

--- a/openshift/minio-deployment.json
+++ b/openshift/minio-deployment.json
@@ -106,10 +106,6 @@
                     "value": "server"
                   },
                   {
-                    "name": "MINIO_CONFIG_DIR",
-                    "value": "/tmp"
-                  },
-                  {
                     "name": "MINIO_DATA_DIR",
                     "value": "/data"
                   }

--- a/openshift/minio-deployment.json
+++ b/openshift/minio-deployment.json
@@ -8,7 +8,7 @@
       "iconClass": "icon-hdd",
       "openshift.io/display-name": "BC Gov Minio",
       "tags": "bcgov,pathfinder,minio,s3,objectstore",
-      "template.openshift.io/documentation-url": "https://github.com/BCDevOps/openshift-tools/tree/master/templates/minio",
+      "template.openshift.io/documentation-url": "https://github.com/BCDevOps/minio-openshift",
       "template.openshift.io/long-description": "This template deploys a minio server within OpenShift, backed by persistent volume storage.",
       "template.openshift.io/provider-display-name": "Province of BC, Office of the Chief Information Officer, BC DevExchange and DevOps Branch"
     }
@@ -100,6 +100,10 @@
                         "key": "minioSecretKey"
                       }
                     }
+                  },
+                  {
+                    "name": "MINIO_MODE",
+                    "value": "server"
                   },
                   {
                     "name": "MINIO_CONFIG_DIR",


### PR DESCRIPTION
Includes an extra var, MINIO_MODE to determine whether MinIO runs in server or gateway mode with a specific cloud provider gateway argument, eg "gateway azure".  Also included other minor fixes such as metadata and label cleanup so templates can also be deployed through the OpenShift web console, and default parameter values that align with MinIO